### PR TITLE
Refactor/flow

### DIFF
--- a/src/app/api/flow/_engine/__test__/graph-builder.test.ts
+++ b/src/app/api/flow/_engine/__test__/graph-builder.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 import type {
   NodeData,
-  ReactFlowEdge,
-  ReactFlowNode,
+  SchemaEdge,
+  SchemaNode,
 } from "@/features/flow/types/graph";
 import { buildGraphFromFlow } from "../graph-builder";
 
@@ -13,7 +13,7 @@ const baseNodeData: NodeData = {
   runStatus: "idle",
 };
 
-const createNode = (overrides: Partial<ReactFlowNode>): ReactFlowNode => ({
+const createNode = (overrides: Partial<SchemaNode>): SchemaNode => ({
   id: "node-id",
   type: "messageNode",
   position: { x: 0, y: 0 },
@@ -21,7 +21,7 @@ const createNode = (overrides: Partial<ReactFlowNode>): ReactFlowNode => ({
   data: { ...baseNodeData, ...overrides.data },
 });
 
-const createEdge = (overrides: Partial<ReactFlowEdge>): ReactFlowEdge => ({
+const createEdge = (overrides: Partial<SchemaEdge>): SchemaEdge => ({
   id: "edge-id",
   source: "node-id",
   target: "node-id-2",
@@ -54,7 +54,7 @@ describe("buildGraphFromFlow", () => {
       position: { x: 200, y: 0 },
     });
 
-    const edges: ReactFlowEdge[] = [
+    const edges: SchemaEdge[] = [
       createEdge({
         id: "edge-1",
         source: searchNode.id,
@@ -92,7 +92,7 @@ describe("buildGraphFromFlow", () => {
       position: { x: 200, y: 0 },
     });
 
-    const edges: ReactFlowEdge[] = [
+    const edges: SchemaEdge[] = [
       createEdge({
         id: "edge-1",
         source: staleSearchNode.id,

--- a/src/app/api/flow/_engine/__test__/graph-builder.test.ts
+++ b/src/app/api/flow/_engine/__test__/graph-builder.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import type {
+  NodeData,
+  ReactFlowEdge,
+  ReactFlowNode,
+} from "@/features/flow/types/graph";
+import { buildGraphFromFlow } from "../graph-builder";
+
+const baseNodeData: NodeData = {
+  label: "",
+  emoji: "",
+  job: "",
+  runStatus: "idle",
+};
+
+const createNode = (overrides: Partial<ReactFlowNode>): ReactFlowNode => ({
+  id: "node-id",
+  type: "messageNode",
+  position: { x: 0, y: 0 },
+  ...overrides,
+  data: { ...baseNodeData, ...overrides.data },
+});
+
+const createEdge = (overrides: Partial<ReactFlowEdge>): ReactFlowEdge => ({
+  id: "edge-id",
+  source: "node-id",
+  target: "node-id-2",
+  type: "custom",
+  ...overrides,
+});
+
+describe("buildGraphFromFlow", () => {
+  it("search-node가 구글 서치와 맵핑되어야 합니다", () => {
+    const searchNode = createNode({
+      id: "search-node",
+      type: "searchNode",
+      data: {
+        label: "search node",
+        emoji: "",
+        job: "검색",
+        nodeType: "searchNode",
+      },
+    });
+
+    const outputNode = createNode({
+      id: "output-node",
+      type: "outputNode",
+      data: {
+        label: "output",
+        emoji: "",
+        job: "종료",
+        nodeType: "outputNode",
+      },
+      position: { x: 200, y: 0 },
+    });
+
+    const edges: ReactFlowEdge[] = [
+      createEdge({
+        id: "edge-1",
+        source: searchNode.id,
+        target: outputNode.id,
+      }),
+    ];
+
+    const { typeMap } = buildGraphFromFlow([searchNode, outputNode], edges);
+
+    expect(typeMap[searchNode.id]).toBe("google_search");
+    expect(typeMap[outputNode.id]).toBe("output");
+  });
+
+  it("node.type을 기준으로 처리해야 합니다", () => {
+    const staleSearchNode = createNode({
+      id: "search-node",
+      type: "searchNode",
+      data: {
+        label: "search node",
+        emoji: "",
+        job: "채팅", // 구식 노드
+        nodeType: "searchNode",
+      },
+    });
+
+    const outputNode = createNode({
+      id: "output-node",
+      type: "outputNode",
+      data: {
+        label: "output",
+        emoji: "",
+        job: "종료",
+        nodeType: "outputNode",
+      },
+      position: { x: 200, y: 0 },
+    });
+
+    const edges: ReactFlowEdge[] = [
+      createEdge({
+        id: "edge-1",
+        source: staleSearchNode.id,
+        target: outputNode.id,
+      }),
+    ];
+
+    const { typeMap } = buildGraphFromFlow(
+      [staleSearchNode, outputNode],
+      edges,
+    );
+
+    expect(typeMap[staleSearchNode.id]).toBe("google_search");
+  });
+});

--- a/src/app/api/flow/_engine/graph-builder.ts
+++ b/src/app/api/flow/_engine/graph-builder.ts
@@ -18,7 +18,7 @@ import type {
   FlowState,
   LangGraphNodeType,
 } from "@/features/flow/types/execution";
-import type { ReactFlowEdge, ReactFlowNode } from "@/features/flow/types/graph";
+import type { SchemaEdge, SchemaNode } from "@/features/flow/types/graph";
 
 // LangGraph 상태 어노테이션 정의
 export const FlowStateAnnotation = Annotation.Root({
@@ -51,7 +51,7 @@ export const FlowStateAnnotation = Annotation.Root({
 export const checkpointer = new MemorySaver();
 
 // 타입 이름 파싱하는 함수
-function determineNodeType(node: ReactFlowNode): LangGraphNodeType {
+function determineNodeType(node: SchemaNode): LangGraphNodeType {
   if (node.type === "inputNode") return "input";
   if (node.type === "outputNode") return "output";
   if (node.data.job === "chat" || node.data.job === "채팅") {
@@ -81,7 +81,7 @@ function determineNodeType(node: ReactFlowNode): LangGraphNodeType {
 /**
  * 분기 노드의 대상 노드들을 찾는 헬퍼 함수
  */
-function findBranchTargets(nodeId: string, edges: ReactFlowEdge[]): string[] {
+function findBranchTargets(nodeId: string, edges: SchemaEdge[]): string[] {
   return edges
     .filter((edge) => edge.source === nodeId)
     .map((edge) => edge.target);
@@ -90,15 +90,15 @@ function findBranchTargets(nodeId: string, edges: ReactFlowEdge[]): string[] {
 /**
  * 병합 노드의 입력 노드들을 찾는 헬퍼 함수
  */
-function findMergeInputs(nodeId: string, edges: ReactFlowEdge[]): string[] {
+function findMergeInputs(nodeId: string, edges: SchemaEdge[]): string[] {
   return edges
     .filter((edge) => edge.target === nodeId)
     .map((edge) => edge.source);
 }
 
 export function buildGraphFromFlow(
-  reactFlowNodes: ReactFlowNode[],
-  reactFlowEdges: ReactFlowEdge[],
+  reactFlowNodes: SchemaNode[],
+  reactFlowEdges: SchemaEdge[],
 ) {
   const graph = new StateGraph(FlowStateAnnotation);
   const typeMap: Record<string, LangGraphNodeType> = {};

--- a/src/app/api/flow/_engine/nodes/__test__/branch-node.test.ts
+++ b/src/app/api/flow/_engine/nodes/__test__/branch-node.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import type { FlowStateAnnotation } from "@/app/api/flow/_engine/graph-builder";
+import { branchNode } from "@/app/api/flow/_engine/nodes/branch-node";
+
+const createState = () =>
+  ({
+    messages: [],
+    prompt: "",
+    currentNodeId: "branch-1",
+    searchResults: [],
+    finalResult: null,
+    nodeOutputs: {},
+  }) as typeof FlowStateAnnotation.State;
+
+describe("branchNode 노드", () => {
+  it("타겟 노드가 있으면 nodeOutputs에 type=branch와 targetNodes가 기록된다", async () => {
+    const state = createState();
+    const nodeId = "branch-1";
+    const targets = ["next-a", "next-b", "next-c"];
+
+    const result = await branchNode(state, nodeId, targets);
+    const output = result.nodeOutputs?.[nodeId];
+
+    expect(output).toBeDefined();
+    expect(output?.type).toBe("branch");
+    expect(output?.targetNodes).toEqual(targets);
+  });
+
+  it("타겟 노드가 없으면 skipped=true와 reason이 기록된다", async () => {
+    const state = createState();
+    const nodeId = "branch-2";
+
+    const result = await branchNode(state, nodeId, []);
+    const output = result.nodeOutputs?.[nodeId];
+
+    expect(output).toBeDefined();
+    expect(output?.type).toBe("branch");
+    expect(output?.skipped).toBe(true);
+    expect(output?.reason).toBe("no targets");
+  });
+});

--- a/src/app/api/flow/_engine/nodes/__test__/chat-node.test.ts
+++ b/src/app/api/flow/_engine/nodes/__test__/chat-node.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  AIMessage,
+  HumanMessage,
+  SystemMessage,
+} from "@langchain/core/messages";
+import { ChatGoogle } from "@langchain/google-gauth";
+import type { FlowStateAnnotation } from "@/app/api/flow/_engine/graph-builder";
+import { chatNode } from "@/app/api/flow/_engine/nodes/chat-node";
+import { DEFAULT_CHAT_MODEL } from "@/features/flow/constants/chat-models";
+
+// 모듈 모킹: ChatGoogle 인스턴스를 가짜로 바꾸고 호출 인자를 검사할 수 있게 함
+const instanceInvoke = vi.fn(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async (_messages: (HumanMessage | SystemMessage)[]) =>
+    new AIMessage("모킹 응답"),
+);
+
+// ChatGoogle 모킹 타입 정의
+interface MockedChatGoogle {
+  invoke: typeof instanceInvoke;
+}
+
+interface MockedConstructor {
+  new (config?: { model?: string }): MockedChatGoogle;
+  mock: {
+    calls: unknown[][];
+  };
+}
+
+vi.mock("@langchain/google-gauth", () => {
+  const ChatGoogle = vi.fn(() => ({
+    invoke: instanceInvoke,
+  })) as unknown as MockedConstructor;
+  return { ChatGoogle };
+});
+
+const baseState = () =>
+  ({
+    messages: [],
+    prompt: "",
+    currentNodeId: "chat-1",
+    searchResults: [],
+    finalResult: null,
+    nodeOutputs: {},
+  }) as typeof FlowStateAnnotation.State;
+
+describe("chatNode 노드", () => {
+  beforeEach(() => {
+    instanceInvoke.mockClear();
+    const MockedChatGoogle = ChatGoogle as unknown as MockedConstructor;
+    MockedChatGoogle.mock?.calls?.splice?.(0);
+  });
+
+  it("직전 메시지를 입력으로 받아 invoke에 전달한다", async () => {
+    const state = baseState();
+    state.messages = [new HumanMessage("직전 메시지")];
+
+    const result = await chatNode(state, { nodeId: "chat-x" });
+
+    // Chat 모델 생성과 호출 확인
+    const MockedChatGoogle = ChatGoogle as unknown as MockedConstructor;
+    expect(MockedChatGoogle.mock.calls.length).toBe(1);
+    expect(instanceInvoke).toHaveBeenCalledTimes(1);
+    const passed = instanceInvoke.mock.calls[0][0];
+    expect(Array.isArray(passed)).toBe(true);
+    // 첫 메시지는 시스템 프롬프트, 두 번째가 직전 메시지
+    expect(passed[0]).toBeInstanceOf(SystemMessage);
+    expect(passed[1]).toBeInstanceOf(HumanMessage);
+    expect(String(passed[1].content)).toBe("직전 메시지");
+
+    // nodeOutputs.chat에 응답 기록
+    expect(result.nodeOutputs?.chat?.response).toBe("모킹 응답");
+  });
+
+  it("모델이 유효하지 않으면 기본 모델로 생성한다", async () => {
+    const state = baseState();
+    state.messages = [new HumanMessage("hi")];
+
+    await chatNode(state, { nodeId: "chat-y", model: "invalid-model" });
+
+    const MockedChatGoogle = ChatGoogle as unknown as MockedConstructor;
+    const call = MockedChatGoogle.mock.calls[0][0] as { model: string };
+    expect(call.model).toBe(DEFAULT_CHAT_MODEL);
+  });
+
+  it("입력 메시지가 없으면 프롬프트 또는 기본 인사를 사용한다", async () => {
+    const state = baseState();
+    state.prompt = "프롬프트 질문";
+
+    await chatNode(state, { nodeId: "chat-z" });
+    const passed = instanceInvoke.mock.calls[0][0];
+    expect(String(passed[1].content)).toBe("프롬프트 질문");
+  });
+});

--- a/src/app/api/flow/_engine/nodes/__test__/google-search-node.test.ts
+++ b/src/app/api/flow/_engine/nodes/__test__/google-search-node.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AIMessage } from "@langchain/core/messages";
+import type { FlowStateAnnotation } from "@/app/api/flow/_engine/graph-builder";
+import { googleSearchNode } from "@/app/api/flow/_engine/nodes/google-search-node";
+
+const createState = () =>
+  ({
+    messages: [] as AIMessage[],
+    prompt: "검색어",
+    currentNodeId: "search-node-123",
+    searchResults: [],
+    finalResult: null,
+    nodeOutputs: {},
+  }) as typeof FlowStateAnnotation.State;
+
+describe("googleSearchNode 노드", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        json: () =>
+          Promise.resolve({
+            items: [
+              {
+                title: "결과",
+                link: "https://example.com",
+                snippet: "설명",
+              },
+            ],
+          }),
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("현재 노드 ID를 사용해서 `nodeOutputs`에 검색 결과를 추가해야 합니다", async () => {
+    const state = createState();
+
+    const result = await googleSearchNode(state);
+    const outputKeys = Object.keys(result.nodeOutputs ?? {});
+
+    expect(outputKeys).toContain(state.currentNodeId);
+  });
+});

--- a/src/app/api/flow/_engine/nodes/__test__/google-search-node.test.ts
+++ b/src/app/api/flow/_engine/nodes/__test__/google-search-node.test.ts
@@ -1,11 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { AIMessage } from "@langchain/core/messages";
+import type { HumanMessage } from "@langchain/core/messages";
 import type { FlowStateAnnotation } from "@/app/api/flow/_engine/graph-builder";
 import { googleSearchNode } from "@/app/api/flow/_engine/nodes/google-search-node";
 
 const createState = () =>
   ({
-    messages: [] as AIMessage[],
+    messages: [] as HumanMessage[],
     prompt: "검색어",
     currentNodeId: "search-node-123",
     searchResults: [],

--- a/src/app/api/flow/_engine/nodes/__test__/input-output-node.test.ts
+++ b/src/app/api/flow/_engine/nodes/__test__/input-output-node.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { HumanMessage } from "@langchain/core/messages";
+import type { FlowStateAnnotation } from "@/app/api/flow/_engine/graph-builder";
+import { inputNode } from "@/app/api/flow/_engine/nodes/input-node";
+import { outputNode } from "@/app/api/flow/_engine/nodes/output-node";
+
+describe("inputNode / outputNode", () => {
+  it("inputNode는 프롬프트를 HumanMessage로 추가하고 nodeOutputs.input을 세팅한다", async () => {
+    const state = {
+      messages: [],
+      prompt: "사용자 질문",
+      currentNodeId: "input-1",
+      searchResults: [],
+      finalResult: null,
+      nodeOutputs: {},
+    } as typeof FlowStateAnnotation.State;
+
+    const result = await inputNode(state);
+
+    expect(result.messages?.[0]).toBeInstanceOf(HumanMessage);
+    expect(String(result.messages?.[0].content)).toBe("사용자 질문");
+    expect(result.nodeOutputs?.input?.prompt).toBe("사용자 질문");
+  });
+
+  it("outputNode는 현재 상태를 최종 결과로 래핑해 반환한다", async () => {
+    const state = {
+      messages: [new HumanMessage("최종 메시지")],
+      prompt: "질문",
+      currentNodeId: "output-1",
+      searchResults: [{ a: 1 }],
+      finalResult: null,
+      nodeOutputs: { foo: { type: "x", timestamp: new Date().toISOString() } },
+    } as typeof FlowStateAnnotation.State;
+
+    const result = await outputNode(state);
+
+    expect(result.finalResult).toBeDefined();
+
+    // finalResult의 타입을 FlowState로 타입 캐스팅
+    const finalResult = result.finalResult as typeof FlowStateAnnotation.State;
+    expect(finalResult?.messages?.length).toBe(1);
+    expect(finalResult?.searchResults?.length).toBe(1);
+    expect(finalResult?.nodeOutputs?.foo).toBeDefined();
+    expect(result.nodeOutputs?.output?.finalResult).toBeDefined();
+  });
+});

--- a/src/app/api/flow/_engine/nodes/__test__/merge-node.test.ts
+++ b/src/app/api/flow/_engine/nodes/__test__/merge-node.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { HumanMessage } from "@langchain/core/messages";
+import type { FlowStateAnnotation } from "@/app/api/flow/_engine/graph-builder";
+import { mergeNode } from "@/app/api/flow/_engine/nodes/merge-node";
+import type { NodeOutput } from "@/features/flow/types/execution";
+
+const baseState = () =>
+  ({
+    messages: [],
+    prompt: "",
+    currentNodeId: "merge-1",
+    searchResults: [],
+    finalResult: null,
+    nodeOutputs: {},
+  }) as typeof FlowStateAnnotation.State;
+
+describe("mergeNode 노드", () => {
+  it("입력 노드들의 메시지 출력을 \n\n으로 병합한다", async () => {
+    const state = baseState();
+    // 선행 노드 출력 모의
+    state.nodeOutputs = {
+      a: {
+        type: "message",
+        rendered: "첫 번째 결과",
+        timestamp: new Date().toISOString(),
+      },
+      b: {
+        type: "message",
+        rendered: "두 번째 결과",
+        timestamp: new Date().toISOString(),
+      },
+    } as Record<string, NodeOutput>;
+
+    const result = await mergeNode(state, "merge-x", ["a", "b"]);
+    const out = result.nodeOutputs?.["merge-x"];
+
+    expect(out).toBeDefined();
+    expect(out?.type).toBe("merge");
+    expect(out?.mergedContent).toBe("첫 번째 결과\n\n두 번째 결과");
+    expect(out?.inputNodeIds).toEqual(["a", "b"]);
+    expect(out?.inputOutputs).toEqual(["첫 번째 결과", "두 번째 결과"]);
+
+    // 병합 결과가 messages에 HumanMessage로 추가됨
+    const last = (result.messages ?? [])[(result.messages?.length || 1) - 1];
+    expect(last).toBeInstanceOf(HumanMessage);
+    expect(last.content).toBe("첫 번째 결과\n\n두 번째 결과");
+  });
+
+  it("입력이 비어있으면 안내 메시지와 에러 필드를 제공한다", async () => {
+    const state = baseState();
+
+    const result = await mergeNode(state, "merge-empty", []);
+    const out = result.nodeOutputs?.["merge-empty"];
+
+    expect(out?.type).toBe("merge");
+    expect(out?.error).toBe("No input nodes connected");
+    const last = result.messages?.[0];
+    expect(last).toBeInstanceOf(HumanMessage);
+    expect(last?.content).toBe("병합할 입력 노드가 연결되지 않았습니다.");
+  });
+
+  it("메시지/AI/입력 타입 외에는 JSON 문자열로 병합한다", async () => {
+    const state = baseState();
+    state.messages = [new HumanMessage("무시될 메시지")];
+    state.nodeOutputs = {
+      x: {
+        type: "custom",
+        value: 123,
+        timestamp: new Date().toISOString(),
+      } as NodeOutput,
+    } as Record<string, NodeOutput>;
+
+    const result = await mergeNode(state, "merge-json", ["x"]);
+    const out = result.nodeOutputs?.["merge-json"];
+    expect(out?.mergedContent).toBe(JSON.stringify(state.nodeOutputs.x));
+  });
+});

--- a/src/app/api/flow/_engine/nodes/__test__/message-node.test.ts
+++ b/src/app/api/flow/_engine/nodes/__test__/message-node.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { AIMessage, HumanMessage } from "@langchain/core/messages";
+import type { FlowStateAnnotation } from "@/app/api/flow/_engine/graph-builder";
+import { messageNode } from "@/app/api/flow/_engine/nodes/message-node";
+
+describe("messageNode 노드", () => {
+  it("템플릿을 렌더링할 때 마지막 메시지가 존재하더라도 프롬프트를 사용해야 한다", async () => {
+    const state = {
+      messages: [
+        new HumanMessage("중간 결과"),
+        new AIMessage("검색 결과 텍스트"),
+      ],
+      prompt: "사용자 입력 프롬프트",
+      currentNodeId: "message-node-1",
+      searchResults: [],
+      finalResult: null,
+      nodeOutputs: {},
+    } as typeof FlowStateAnnotation.State;
+
+    const result = await messageNode(state, "message-node-1", "요약: {input}");
+    const rendered = result.nodeOutputs?.["message-node-1"]?.rendered;
+
+    expect(rendered).toBe("요약: 사용자 입력 프롬프트");
+  });
+
+  it("템플릿이 전달되지 않으면 기본 템플릿을 사용하고, 입력값이 없으면 빈 문자열로 대체되어야 한다", async () => {
+    const state = {
+      messages: [],
+      prompt: "",
+      currentNodeId: "message-node-2",
+      searchResults: [],
+      finalResult: null,
+      nodeOutputs: {},
+    } as typeof FlowStateAnnotation.State;
+
+    const result = await messageNode(state, "message-node-2");
+    const output = result.nodeOutputs?.["message-node-2"];
+
+    expect(output).toBeDefined();
+    expect(output?.template).toBe("기본 메시지: {input}");
+    expect(output?.rendered).toBe("기본 메시지: ");
+  });
+
+  it("nodeOutputs에 input과 rendered 필드가 포함되어야 한다", async () => {
+    const state = {
+      messages: [new HumanMessage("안녕하세요")],
+      prompt: "무시되는 프롬프트",
+      currentNodeId: "message-node-3",
+      searchResults: [],
+      finalResult: null,
+      nodeOutputs: {},
+    } as typeof FlowStateAnnotation.State;
+
+    const result = await messageNode(state, "message-node-3", "확인: {input}");
+    const output = result.nodeOutputs?.["message-node-3"];
+
+    expect(output?.input).toBe("안녕하세요");
+    expect(output?.rendered).toBe("확인: 안녕하세요");
+  });
+});

--- a/src/app/api/flow/_engine/nodes/__test__/message-node.test.ts
+++ b/src/app/api/flow/_engine/nodes/__test__/message-node.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { AIMessage, HumanMessage } from "@langchain/core/messages";
+import { HumanMessage } from "@langchain/core/messages";
 import type { FlowStateAnnotation } from "@/app/api/flow/_engine/graph-builder";
 import { messageNode } from "@/app/api/flow/_engine/nodes/message-node";
 
@@ -8,7 +8,7 @@ describe("messageNode 노드", () => {
     const state = {
       messages: [
         new HumanMessage("중간 결과"),
-        new AIMessage("검색 결과 텍스트"),
+        new HumanMessage("검색 결과 텍스트"),
       ],
       prompt: "사용자 입력 프롬프트",
       currentNodeId: "message-node-1",

--- a/src/features/flow/types/execution.ts
+++ b/src/features/flow/types/execution.ts
@@ -1,15 +1,15 @@
 import type { BaseMessage } from "@langchain/core/messages";
 import type {
-  NodeId,
-  ReactFlowEdge,
-  ReactFlowNode,
+  FlowNodeId,
+  SchemaEdge,
+  SchemaNode,
 } from "@/features/flow/types/graph";
 
 type Primitive = string | number | boolean | null | undefined;
 type ComplexValue = Primitive | object;
 
 interface FlowEventBase {
-  nodeId: NodeId;
+  nodeId: FlowNodeId;
   event: string;
   message?: string;
   error?: string;
@@ -52,15 +52,15 @@ export interface NodeOutput {
 export interface FlowState {
   messages: BaseMessage[];
   prompt: string;
-  currentNodeId?: NodeId;
+  currentNodeId?: FlowNodeId;
   searchResults?: ComplexValue[];
   finalResult?: ComplexValue;
-  nodeOutputs: Record<NodeId, NodeOutput>;
+  nodeOutputs: Record<FlowNodeId, NodeOutput>;
 }
 
 export interface FlowExecutionRequest {
-  nodes: ReactFlowNode[];
-  edges: ReactFlowEdge[];
+  nodes: SchemaNode[];
+  edges: SchemaEdge[];
   prompt: string;
 }
 

--- a/src/features/flow/types/graph.ts
+++ b/src/features/flow/types/graph.ts
@@ -55,8 +55,3 @@ export interface SchemaEdge
   targetHandle?: FlowEdgeRow["targetHandle"] | undefined;
   label?: FlowEdgeRow["label"] | undefined;
 }
-
-export type ReactFlowNode = SchemaNode;
-export type ReactFlowEdge = SchemaEdge;
-
-export type NodeId = FlowNodeId;

--- a/src/features/flow/types/node-ui.ts
+++ b/src/features/flow/types/node-ui.ts
@@ -1,9 +1,9 @@
 import type { CSSProperties, ComponentType } from "react";
 import type { Position } from "@xyflow/react";
 import type {
+  FlowNodeId,
   FlowNodeType,
   NodeData,
-  NodeId,
 } from "@/features/flow/types/graph";
 
 export interface NodeConfig {
@@ -31,7 +31,7 @@ export interface SidebarItemConfig {
 }
 
 export interface ConnectionLimit {
-  id: NodeId;
+  id: FlowNodeId;
   max: number;
 }
 
@@ -46,19 +46,19 @@ export interface ConnectionState {
   isConnectable: boolean;
 }
 
-export type ConnectionStateMap = Record<NodeId, ConnectionState>;
+export type ConnectionStateMap = Record<FlowNodeId, ConnectionState>;
 
 export interface HandleDefinition {
   type: "source" | "target";
   position: Position;
-  id: NodeId;
+  id: FlowNodeId;
   size?: "large" | "small";
   style?: CSSProperties;
 }
 
 export interface NodeProps {
   data: NodeData;
-  id: NodeId;
+  id: FlowNodeId;
 }
 
 export interface MenuItem {

--- a/src/features/flow/utils/__test__/workflow-transformers.test.ts
+++ b/src/features/flow/utils/__test__/workflow-transformers.test.ts
@@ -1,0 +1,383 @@
+import { describe, expect, it } from "vitest";
+// eslint-disable-next-line import/no-restricted-paths
+import { buildGraphFromFlow } from "@/app/api/flow/_engine/graph-builder";
+import type {
+  FlowEdgeInsert,
+  FlowNodeInsert,
+  SchemaNode,
+} from "@/features/flow/types/graph";
+import type { WorkflowApiDetail } from "@/features/flow/types/workflow-api";
+import {
+  calculateTemplateInsertion,
+  createRandomEdgeId,
+  createRandomGroupId,
+} from "@/features/flow/utils/canvas";
+import {
+  deserializeWorkflowDetail,
+  mapRowToSchemaEdge,
+  mapRowToSchemaNode,
+  serializeEdgeForApi,
+  serializeNodeForApi,
+} from "@/features/flow/utils/workflow-transformers";
+
+const createMismatchedNode = (): SchemaNode => ({
+  id: "node-search",
+  type: "searchNode",
+  position: { x: 120, y: 45 },
+  data: {
+    label: "검색 노드",
+    emoji: "",
+    job: "채팅",
+    nodeType: "searchNode",
+    runStatus: "idle",
+  },
+});
+
+// 데이터가 그대로 유지되는지 확인
+describe("워크플로우 변환기", () => {
+  it("serializeNodeForApi가 일치하지 않는 job 메타데이터를 그대로 유지해야 한다", () => {
+    const node = createMismatchedNode();
+
+    const payload = serializeNodeForApi(node);
+
+    expect(payload.data).toMatchObject({ job: "채팅" });
+    expect(payload.type).toBe("searchNode");
+  });
+
+  it("deserializeWorkflowDetail이 직렬화-역직렬화 후에도 이전 job 데이터를 보존해야 한다", () => {
+    const node = createMismatchedNode();
+    const serialized = serializeNodeForApi(node);
+
+    const workflowDetail: WorkflowApiDetail = {
+      id: "workflow-1",
+      name: "검색 흐름",
+      description: null,
+      updatedAt: new Date(),
+      isOwner: true,
+      isLicensed: false,
+      nodes: [
+        {
+          id: serialized.id,
+          type: serialized.type,
+          posX: serialized.posX,
+          posY: serialized.posY,
+          data: serialized.data as Record<string, string>,
+        },
+      ],
+      edges: [],
+    };
+
+    const deserialized = deserializeWorkflowDetail(workflowDetail);
+
+    expect(deserialized.nodes[0].type).toBe("searchNode");
+    expect(deserialized.nodes[0].data.job).toBe("채팅");
+  });
+
+  it("mapRowToSchemaNode가 타입으로부터 추론하지 않고 저장된 job 값을 유지해야 한다", () => {
+    const insertRow: FlowNodeInsert = {
+      id: "node-db",
+      workflowId: "workflow-1",
+      type: "searchNode",
+      posX: 10,
+      posY: 20,
+      data: {
+        label: "검색",
+        emoji: "",
+        job: "채팅",
+        nodeType: "searchNode",
+      },
+    };
+
+    const schemaNode = mapRowToSchemaNode(insertRow);
+
+    expect(schemaNode.type).toBe("searchNode");
+    expect(schemaNode.data.job).toBe("채팅");
+  });
+
+  it("mapRowToSchemaNode가 data가 null일 때 빈 job으로 대체되어야 한다", () => {
+    const insertRow: FlowNodeInsert = {
+      id: "node-empty",
+      workflowId: "workflow-2",
+      type: "messageNode",
+      posX: 0,
+      posY: 0,
+      data: null,
+    };
+
+    const schemaNode = mapRowToSchemaNode(insertRow);
+
+    expect(schemaNode.data.job).toBe("");
+    expect(schemaNode.data.label).toBe("");
+  });
+
+  it("serializeEdgeForApi와 mapRowToSchemaEdge가 노드 연결을 변경하지 않고 왕복되어야 한다", () => {
+    const edgeInsert: FlowEdgeInsert = {
+      id: "edge-1",
+      workflowId: "workflow-1",
+      sourceId: "node-a",
+      targetId: "node-b",
+      label: "흐름",
+      sourceHandle: "right",
+      targetHandle: "left",
+      order: 2,
+    };
+
+    const schemaEdge = mapRowToSchemaEdge(edgeInsert);
+    expect(schemaEdge.source).toBe("node-a");
+    expect(schemaEdge.target).toBe("node-b");
+
+    const serialized = serializeEdgeForApi(schemaEdge);
+    expect(serialized.sourceId).toBe("node-a");
+    expect(serialized.targetId).toBe("node-b");
+    expect(serialized.label).toBe("흐름");
+    expect(serialized.order).toBeNull();
+  });
+
+  it("deserializeWorkflowDetail이 혼합 노드 타입에 대해 노드별 메타데이터를 유지해야 한다", () => {
+    const workflowDetail: WorkflowApiDetail = {
+      id: "workflow-3",
+      name: "복합 플로우",
+      description: "",
+      updatedAt: new Date(),
+      isOwner: true,
+      isLicensed: false,
+      nodes: [
+        {
+          id: "input-1",
+          type: "inputNode",
+          posX: 0,
+          posY: 0,
+          data: { label: "시작", emoji: "", job: "시작" },
+        },
+        {
+          id: "chat-1",
+          type: "chatNode",
+          posX: 150,
+          posY: 0,
+          data: {
+            label: "채팅",
+            emoji: "",
+            job: "채팅",
+            nodeType: "chatNode",
+            model: "gpt-4",
+          },
+        },
+        {
+          id: "search-1",
+          type: "searchNode",
+          posX: 300,
+          posY: 0,
+          data: {
+            label: "검색",
+            emoji: "",
+            job: "검색",
+            nodeType: "searchNode",
+          },
+        },
+      ],
+      edges: [
+        {
+          id: "edge-1",
+          sourceId: "input-1",
+          targetId: "chat-1",
+          sourceHandle: null,
+          targetHandle: null,
+          label: null,
+          order: null,
+        },
+        {
+          id: "edge-2",
+          sourceId: "chat-1",
+          targetId: "search-1",
+          sourceHandle: "right",
+          targetHandle: "left",
+          label: "연결",
+          order: 1,
+        },
+      ],
+    };
+
+    const detail = deserializeWorkflowDetail(workflowDetail);
+
+    expect(detail.nodes.map((node) => node.data.job)).toEqual([
+      "시작",
+      "채팅",
+      "검색",
+    ]);
+    expect(detail.nodes[1].data.model).toBe("gpt-4");
+    expect(detail.edges[1].label).toBe("연결");
+  });
+
+  it("calculateTemplateInsertion이 워크플로우 상세 노드들의 job 메타데이터를 보존해야 한다", () => {
+    const workflowDetail = deserializeWorkflowDetail({
+      id: "workflow-4",
+      name: "템플릿",
+      description: null,
+      updatedAt: new Date(),
+      nodes: [
+        {
+          id: "input-id",
+          type: "inputNode",
+          posX: 0,
+          posY: 0,
+          data: {
+            label: "입력",
+            emoji: "",
+            job: "입력",
+            nodeType: "inputNode",
+          },
+        },
+        {
+          id: "search-id",
+          type: "searchNode",
+          posX: 200,
+          posY: 50,
+          data: {
+            label: "검색",
+            emoji: "",
+            job: "검색",
+            nodeType: "searchNode",
+            runStatus: "idle",
+          },
+        },
+        {
+          id: "chat-id",
+          type: "chatNode",
+          posX: 400,
+          posY: 50,
+          data: {
+            label: "채팅",
+            emoji: "",
+            job: "채팅",
+            nodeType: "chatNode",
+            model: "gpt-4o",
+            runStatus: "idle",
+          },
+        },
+      ],
+      edges: [
+        {
+          id: "edge-input-search",
+          sourceId: "input-id",
+          targetId: "search-id",
+          sourceHandle: "right",
+          targetHandle: "left",
+          label: null,
+          order: null,
+        },
+        {
+          id: "edge-search-chat",
+          sourceId: "search-id",
+          targetId: "chat-id",
+          sourceHandle: "right",
+          targetHandle: "left",
+          label: "연결",
+          order: 1,
+        },
+      ],
+    });
+
+    const generatorSequence = (() => {
+      let counter = 0;
+      return () => `generated-${++counter}`;
+    })();
+
+    const insertion = calculateTemplateInsertion(
+      workflowDetail,
+      { x: 100, y: 100 },
+      {
+        generateNodeId: generatorSequence,
+        generateEdgeId: createRandomEdgeId,
+        generateGroupId: createRandomGroupId,
+      },
+    );
+
+    expect(insertion).not.toBeNull();
+    const resolvedInsertion = insertion!;
+
+    const searchNode = resolvedInsertion.nodesToAdd.find(
+      (node) => node.type === "searchNode",
+    );
+    expect(searchNode).toBeDefined();
+    expect(searchNode?.data.job).toBe("검색");
+    expect(searchNode?.data.nodeType).toBe("searchNode");
+  });
+
+  it("buildGraphFromFlow가 템플릿 삽입에서 생성된 노드를 google_search로 분류해야 한다", () => {
+    const workflowDetail = deserializeWorkflowDetail({
+      id: "workflow-5",
+      name: "검증 템플릿",
+      description: null,
+      updatedAt: new Date(),
+      nodes: [
+        {
+          id: "input-id",
+          type: "inputNode",
+          posX: 0,
+          posY: 0,
+          data: {
+            label: "입력",
+            emoji: "",
+            job: "입력",
+            nodeType: "inputNode",
+          },
+        },
+        {
+          id: "search-id",
+          type: "searchNode",
+          posX: 180,
+          posY: 60,
+          data: {
+            label: "검색",
+            emoji: "",
+            job: "검색",
+            nodeType: "searchNode",
+          },
+        },
+      ],
+      edges: [
+        {
+          id: "edge-input-search",
+          sourceId: "input-id",
+          targetId: "search-id",
+          sourceHandle: null,
+          targetHandle: null,
+          label: null,
+          order: null,
+        },
+      ],
+    });
+
+    const generatorSequence = (() => {
+      let counter = 0;
+      return () => `node-${++counter}`;
+    })();
+
+    const insertion = calculateTemplateInsertion(
+      workflowDetail,
+      { x: 200, y: 200 },
+      {
+        generateNodeId: generatorSequence,
+        generateEdgeId: createRandomEdgeId,
+        generateGroupId: createRandomGroupId,
+      },
+    );
+
+    expect(insertion).not.toBeNull();
+    const resolvedInsertion = insertion!;
+
+    const { typeMap } = buildGraphFromFlow(
+      resolvedInsertion.nodesToAdd,
+      resolvedInsertion.edgesToAdd,
+    );
+
+    const createdSearchNode = resolvedInsertion.nodesToAdd.find(
+      (node) => node.type === "searchNode",
+    );
+    expect(createdSearchNode).toBeDefined();
+
+    expect(createdSearchNode && typeMap[createdSearchNode.id]).toBe(
+      "google_search",
+    );
+  });
+});

--- a/src/features/flow/utils/workflow-transformers.ts
+++ b/src/features/flow/utils/workflow-transformers.ts
@@ -2,7 +2,6 @@ import type {
   FlowEdgeInsert,
   FlowNodeInsert,
   NodeData,
-  ReactFlowEdge,
   SchemaEdge,
   SchemaNode,
 } from "@/features/flow/types/graph";
@@ -87,7 +86,7 @@ export const serializeNodeForApi = (node: SchemaNode) => ({
   data: (node.data as Record<string, unknown>) ?? null,
 });
 
-export const serializeEdgeForApi = (edge: ReactFlowEdge | SchemaEdge) => ({
+export const serializeEdgeForApi = (edge: SchemaEdge | SchemaEdge) => ({
   id: edge.id,
   sourceId: edge.source,
   targetId: edge.target,

--- a/src/features/flow/utils/workflow-transformers.ts
+++ b/src/features/flow/utils/workflow-transformers.ts
@@ -86,7 +86,7 @@ export const serializeNodeForApi = (node: SchemaNode) => ({
   data: (node.data as Record<string, unknown>) ?? null,
 });
 
-export const serializeEdgeForApi = (edge: SchemaEdge | SchemaEdge) => ({
+export const serializeEdgeForApi = (edge: SchemaEdge) => ({
   id: edge.id,
   sourceId: edge.source,
   targetId: edge.target,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,14 +1,14 @@
-import path from "node:path";
-import { fileURLToPath } from "node:url";
 import tsconfigPaths from "vite-tsconfig-paths";
 import { defineConfig } from "vitest/config";
-import { storybookTest } from "@storybook/addon-vitest/vitest-plugin";
 import react from "@vitejs/plugin-react";
 
-const dirname =
-  typeof __dirname !== "undefined"
-    ? __dirname
-    : path.dirname(fileURLToPath(import.meta.url));
+// import path from "node:path";
+// import { fileURLToPath } from "node:url";
+// import { storybookTest } from "@storybook/addon-vitest/vitest-plugin";
+// const dirname =
+//   typeof __dirname !== "undefined"
+//     ? __dirname
+//     : path.dirname(fileURLToPath(import.meta.url));
 
 // More info at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon
 export default defineConfig({
@@ -27,7 +27,7 @@ export default defineConfig({
       include: ["src/**"],
       exclude: [
         "src/**/*.test.{ts,tsx}",
-        "src/**/*.stories.{ts,tsx}",
+        // "src/**/*.stories.{ts,tsx}",
         "src/testing/**",
         "src/**/*.d.ts",
         "src/app/layout.tsx",
@@ -47,9 +47,9 @@ export default defineConfig({
         plugins: [
           // The plugin will run tests for the stories defined in your Storybook config
           // See options at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon#storybooktest
-          storybookTest({
-            configDir: path.join(dirname, ".storybook"),
-          }),
+          // storybookTest({
+          //   configDir: path.join(dirname, ".storybook"),
+          // }),
         ],
         test: {
           name: "storybook",


### PR DESCRIPTION
버그를 잡기 위해 테스트 코드를 추가하고 있어요
1. 각 랭그래프 노드는 마지막 아웃풋을 인풋으로 받는데, 해당 인풋은 'humanmessage'에요

------------
This pull request introduces a comprehensive refactor and improvement of the flow engine's type system and adds extensive unit tests for node execution logic. The most significant changes are the replacement of ambiguous or legacy node/edge types with consistent schema-based types throughout the flow engine and related type definitions, as well as the addition of robust test coverage for all core node behaviors.

**Type System Refactoring:**

- Replaced all usages of `ReactFlowNode`, `ReactFlowEdge`, and `NodeId` with `SchemaNode`, `SchemaEdge`, and `FlowNodeId` respectively in the flow engine, type definitions, and UI-related types, ensuring type consistency and clarity throughout the codebase. [[1]](diffhunk://#diff-87995f81c32b5a4839446aea329c347fea82344959ce97b1820d7a2c513fa816L21-R21) [[2]](diffhunk://#diff-87995f81c32b5a4839446aea329c347fea82344959ce97b1820d7a2c513fa816L54-R54) [[3]](diffhunk://#diff-87995f81c32b5a4839446aea329c347fea82344959ce97b1820d7a2c513fa816L84-R84) [[4]](diffhunk://#diff-87995f81c32b5a4839446aea329c347fea82344959ce97b1820d7a2c513fa816L93-R101) [[5]](diffhunk://#diff-337c8cb9d60d9abe76efd896d41e709084d85ddec714b2b0d7c8885212b66e68L3-R12) [[6]](diffhunk://#diff-337c8cb9d60d9abe76efd896d41e709084d85ddec714b2b0d7c8885212b66e68L55-R63) [[7]](diffhunk://#diff-d1e024c98ffc59fac6e26b45cf7b8fef6f0ef37a6fe68aa1dc983c8a38fcb400L58-L62) [[8]](diffhunk://#diff-02948b1faeff24ba18e0b090dcf6ca7fb8be96185e0e962822946b46c7204eedR4-L6) [[9]](diffhunk://#diff-02948b1faeff24ba18e0b090dcf6ca7fb8be96185e0e962822946b46c7204eedL34-R34) [[10]](diffhunk://#diff-02948b1faeff24ba18e0b090dcf6ca7fb8be96185e0e962822946b46c7204eedL49-R61)

**Test Coverage Improvements:**

- Added comprehensive unit tests for all core node types, including `branchNode`, `chatNode`, `googleSearchNode`, `inputNode`, `outputNode`, `mergeNode`, and `messageNode`. These tests cover expected behaviors, edge cases, and error handling for each node. [[1]](diffhunk://#diff-23b1d1c2c41bf93a66abd469328491db62d67a37379551b470b3d833adf814a8R1-R41) [[2]](diffhunk://#diff-1903db631199b847daa76b66a3c379fee479d0435f27d1dd65b8732ad3ee6e0fR1-R95) [[3]](diffhunk://#diff-af353c34ed7df5897d9ae721d16c25e016f0b6c1cd2a1d9fa71a3e947e55621aR1-R47) [[4]](diffhunk://#diff-a3fbaf81a10a27c5507e7b6c0c91fa3f1c01831cd3edd470a5e60db597946e70R1-R46) [[5]](diffhunk://#diff-1f8d6e604c083f65d4eb68c59feee8f0ef838b9d94968ef8d32aac2b1cfcdc5eR1-R77) [[6]](diffhunk://#diff-8ba8b2bc58ea9d446f15d5d323ce2a4236902a532c5d91a440dfd189c5e9574bR1-R60)
- Added tests for the `buildGraphFromFlow` function, ensuring correct mapping of node types and handling of legacy node data.

These changes improve the maintainability, reliability, and clarity of the flow engine, and ensure that future changes can be made with greater confidence due to the improved test coverage and type safety.